### PR TITLE
Bumps version to 0.1.7.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.example.hochi.nextcompanion"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 7
-        versionName "0.1.6"
+        versionCode 8
+        versionName "0.1.7.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {


### PR DESCRIPTION
We forgot to bump the Version{Name.Code} in the previous tag.