### PR TITLE
[Bugfix] Fix logout bug

### DIFF
--- a/app/src/main/java/com/example/hochi/nextcompanion/MainActivity.java
+++ b/app/src/main/java/com/example/hochi/nextcompanion/MainActivity.java
@@ -81,7 +81,7 @@ public class MainActivity extends AppCompatActivity implements AsyncTaskCallback
         if (id == R.id.action_logout) {
             SharedPreferences sharedPref = getSharedPreferences("persistence", MODE_PRIVATE);
             SharedPreferences.Editor editor = sharedPref.edit();
-            editor.remove("loginkey");
+            editor.remove("loginKey");
             editor.apply();
             Intent intent = new Intent(this, LoginActivity.class);
             startActivity(intent);


### PR DESCRIPTION
On a logout the login-key has not been removed from the shared preferences due to a typo ("loginkey" instead of "loginKey"). Now that the typo is fixed the login key is no longer kept stored after logouts which resolves the bug mentioned in issue #16